### PR TITLE
Fix null pointer when there is no admin user

### DIFF
--- a/src/AuditTrailModule/javasource/audittrail/log/CreateLogObject.java
+++ b/src/AuditTrailModule/javasource/audittrail/log/CreateLogObject.java
@@ -92,7 +92,9 @@ public class CreateLogObject {
 			try {
 				final List<IMendixObject> administrators = Core.retrieveXPathQuery(sudoContext, "//" + User.getType() + "["
 						+ User.MemberNames.Name + "='" + Core.getConfiguration().getAdminUserName() + "']");
-				userObjectId = administrators.get(0).getId();
+				if (administrators.size() > 0) {
+					userObjectId = administrators.get(0).getId();
+				}
 			} catch (final CoreException e1) {
 				logNode.error("MxAdmin not found");
 			}

--- a/src/AuditTrailModule/javasource/test_crm/tests/TestNoAdminAction.java
+++ b/src/AuditTrailModule/javasource/test_crm/tests/TestNoAdminAction.java
@@ -1,24 +1,65 @@
 package test_crm.tests;
 
-import com.mendix.core.CoreException;
+import java.util.Date;
+import java.util.List;
 
+import com.mendix.core.Core;
+import com.mendix.core.CoreException;
+import com.mendix.systemwideinterfaces.core.IMendixObject;
+
+import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
+
+import system.proxies.Language;
+import system.proxies.TimeZone;
+import system.proxies.User;
+import system.proxies.UserRole;
 
 /**
  * This class tests adding, changing and deleting objects of Company by using
  * the TestAuditInheritance class. However, here we remove the admin user who
- * performs the action to make sure we are able to log these actions.
+ * performs the action to make sure we are able to log these actions. We also
+ * remove its sessions, so we get kicked out of the application after the test
+ * runs.
  * 
- * Because of this, the database gets in an inconsistent state and this test is
- * usually commented out.
+ * After the test runs, another admin user with the same name and password
+ * "P@ssw0rd" is created.
  */
-@Ignore("Unable to continue running the tests if we delete the admin user")
 public class TestNoAdminAction extends TestAuditInheritance {
+	private List<UserRole> adminRoles;
+	private Language adminLanguage;
+	private TimeZone adminTz;
+
 	@Before
 	public void beforeTesting() throws CoreException {
 		super.beforeTesting();
+		this.adminRoles = this.admin.getUserRoles();
+		this.adminLanguage = this.admin.getUser_Language();
+		this.adminTz = this.admin.getUser_TimeZone();
+		
+		List<IMendixObject> sessions = Core.retrieveXPathQuery(this.context,
+			String.format("//System.Session[System.Session_User/System.User/ID='%1$d']", this.admin.getMendixObject().getId().toLong()));
+		Core.delete(this.context, sessions);
 		this.admin.delete();
 		this.admin = null;
+	}
+
+	@After
+	public void afterTesting() throws CoreException {
+		// We recreate the admin user here so all tests can still run until the end,
+		// even if we are not logged in as that user.
+		final User newAdmin = User.load(this.context, Core.instantiate(this.context, "Administration.Account").getId());
+		newAdmin.setActive(true);
+		newAdmin.setBlocked(false);
+		newAdmin.setFailedLogins(0);
+		newAdmin.setIsAnonymous(false);
+		newAdmin.setLastLogin(new Date());
+		newAdmin.setName(Core.getConfiguration().getAdminUserName());
+		newAdmin.setPassword("P@ssw0rd");
+		newAdmin.setUserRoles(this.adminRoles);
+		newAdmin.setUser_Language(this.adminLanguage);
+		newAdmin.setUser_TimeZone(this.adminTz);
+		newAdmin.setWebServiceUser(false);
+		newAdmin.commit();
 	}
 }

--- a/src/AuditTrailModule/javasource/test_crm/tests/TestNoAdminAction.java
+++ b/src/AuditTrailModule/javasource/test_crm/tests/TestNoAdminAction.java
@@ -1,0 +1,24 @@
+package test_crm.tests;
+
+import com.mendix.core.CoreException;
+
+import org.junit.Before;
+import org.junit.Ignore;
+
+/**
+ * This class tests adding, changing and deleting objects of Company by using
+ * the TestAuditInheritance class. However, here we remove the admin user who
+ * performs the action to make sure we are able to log these actions.
+ * 
+ * Because of this, the database gets in an inconsistent state and this test is
+ * usually commented out.
+ */
+@Ignore("Unable to continue running the tests if we delete the admin user")
+public class TestNoAdminAction extends TestAuditInheritance {
+	@Before
+	public void beforeTesting() throws CoreException {
+		super.beforeTesting();
+		this.admin.delete();
+		this.admin = null;
+	}
+}

--- a/src/AuditTrailModule/javasource/test_crm/tests/expected/ExpectedLog.java
+++ b/src/AuditTrailModule/javasource/test_crm/tests/expected/ExpectedLog.java
@@ -147,7 +147,11 @@ public class ExpectedLog {
 		else
 			builder.append(" attributes changed by  ");
 
-		builder.append(this.logUser.getName());
+		if (this.logUser == null) {
+			builder.append("[unknown]");
+		} else {
+			builder.append(this.logUser.getName());
+		}
 		builder.append(" on ");
 		// Assuming we're not using US locale for testing
 		final SimpleDateFormat dateFormatter = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss '(UTC)'");


### PR DESCRIPTION
This PR fixes logging when there are no admin users in the application. There is one extra test, based on `TestAuditInheritance` with the exception that this test deletes the admin user before running.

~However, I was unable to adjust the automated test to run well after this new class ran, as we mess up the active sessions when we delete the current user. Therefore, this test is currently `@Ignore`d. The entire battery should still run fine at least once when the ignore annotation is commented out.~

I delete the sessions and recreate the admin user at the end of the test. This way we do not need to ignore the test. However, we do need to log-in again after running the tests.

RN: Fix NullPointerException when no admin is present. In these scenarios, we log the action as performed by `[unknown]`. (Ticket 77281.)