### PR TITLE
[DAT-3255] Exclude other modules for Snyk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ build
 *.launch
 *.lock
 **/proxies/
+/.idea/
+/.dccache

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,6 @@
+exclude:
+  global:
+    - javasource/objecthandling
+    - javasource/system
+    - javasource/test_crm
+    - javasource/unittesting


### PR DESCRIPTION
Excluding dependent modules from Snyk, so that only the code for this module is scanned.