### PR TITLE
Always log unchanged attributes on deletion

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=9.0.2
+version=9.0.3

--- a/marketplace/release-notes/8.1.3.txt
+++ b/marketplace/release-notes/8.1.3.txt
@@ -1,0 +1,1 @@
+We now log all attributes of a deleted object even if 'IncludeOnlyChangedAttributes' is set to True. Before, no attributes would be logged on deletion.

--- a/marketplace/release-notes/9.0.3.txt
+++ b/marketplace/release-notes/9.0.3.txt
@@ -1,0 +1,1 @@
+We now log all attributes of a deleted object even if 'IncludeOnlyChangedAttributes' is set to True. Before, no attributes would be logged on deletion.


### PR DESCRIPTION
When IncludeOnlyChangedAttributes = true, no attributes were available in the log line, so it was not possible to understand which object is deleted. Now we log all attributes on deletion regardless of that flag.

Based on https://github.com/mendix/AuditTrailModule/pull/32