### PR TITLE
Let junit helper version depend on Mendix version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,10 +29,13 @@ repositories {
     }
 }
 
+String[] value = project.ext.mxInstallVersion.tokenize(".")
+String junitHelperVersion = (value[0].toInteger() * 100 + value[1].toInteger()) < 1111 ? "1.2.0" : "1.3.0"
+
 dependencies {
     implementation(fileTree(mxRuntimeBundles).include('*.jar'))
-    
-    testImplementation('com.mendix.util:junit-helper:1.2.0') {
+
+    testImplementation('com.mendix.util:junit-helper:' + junitHelperVersion) {
         exclude group: 'com.mendix', module: 'public-api'
     }
 

--- a/environment.gradle
+++ b/environment.gradle
@@ -4,6 +4,9 @@ def mxPathDefault = (System.getProperty('os.name').startsWith('Windows'))
 def mxPath = System.getenv('MX_INSTALL_PATH') ?: System.getProperty('MX_INSTALL_PATH') ?: mxPathDefault
 def mxInstallVersion = System.getenv('MODELER_VERSION') ?: System.getenv('MX_INSTALL_VERSION') ?: System.getProperty('MX_INSTALL_VERSION') ?: '10.21.0.64362'
 
+System.out.println("mxInstallVersion = ${mxInstallVersion}")
+
+project.ext.mxInstallVersion = mxInstallVersion
 project.ext.mxInstallPath = "${mxPath}/${mxInstallVersion}"
 project.ext.mxRuntimeBundles = new File("${mxInstallPath}/runtime/bundles")
 project.ext.ossClearanceFile = file("SiemensMendixAudittrail__10.2.1__READMEOSS.html")


### PR DESCRIPTION
Now that the Mendix runtime uses Scala 3, we need to use a different version of junit-helper for recent Mendix versions. This change is only for running the tests, it does not affect the published module.